### PR TITLE
fix for #17 - static middleware interferes with multipart file processing

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -508,7 +508,7 @@ Request.prototype.body = function body(callback) {
                 if (length !== buffer.length) {
                     input.pause();
                     var message = "Error parsing multipart body: " + length + " of " + buffer.length + " bytes parsed";
-                    callback(new strata.InvalidRequestBody(message), params);
+                    callback(new strata.InvalidRequestBodyError(message), params);
                 }
             });
 
@@ -517,7 +517,7 @@ Request.prototype.body = function body(callback) {
                     parser.end();
                 } catch (e) {
                     var message = "Error parsing multipart body";
-                    callback(new strata.InvalidRequestBody(message, e), params);
+                    callback(new strata.InvalidRequestBodyError(message, e), params);
                 }
             });
         } else {

--- a/lib/static.js
+++ b/lib/static.js
@@ -31,6 +31,10 @@ module.exports = function (app, root, index) {
     }
 
     return function stat(env, callback) {
+        if ( /multipart/.test(env.contentType) ) {
+          return app(env, callback);
+        }
+
         var pathInfo = unescape(env.pathInfo),
             fullPath = path.join(root, pathInfo);
 


### PR DESCRIPTION
This patch adds a check to the static middleware if contentType contains "multipart", which fixes issue #17. The test suite is a bit complex for me to grok at the moment, but I'm welcome to any suggestions for how to get test coverage for this.

Also fixed 2 bad references to InvalidRequestBody => InvalidRequestBodyError in multipart request handlers
