### PR TITLE
Remove gzgbz2 from dependencies

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -1,6 +1,17 @@
 var util = require("util"),
-    BufferedStream = require("bufferedstream"),
+    BufferedStream = require("bufferedstream");
+
+try {
+    // This shim is for node < 0.6 only. gzbz2 is not in the dependecies, as
+    // it can't be installed on node >= 0.6. Instead we have this workaround
+    // until strata will lift it's engine dependency.
     Gzip = require("gzbz2").Gzip;
+} catch (e) {
+    throw new Error("Required module gzbz2 not found.\n" +
+                    "Please, upgrade your node to the latest stable to have " +
+                    "built-in Zlib module, or install `gzbz2` manually with " +
+                    "`npm install gzbz2`");
+}
 
 exports.createGzip = createGzip;
 exports.GzipStream = GzipStream;

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
         "bufferedstream": "~1.0.1",
         "mime": "1.2.3",
         "strftime": "0.4.6",
-        "markdown": "~0.3.1",
-        "gzbz2": "0.1.0"
+        "markdown": "~0.3.1"
     },
     "devDependencies": {
         "vows": "0.6.0",


### PR DESCRIPTION
This patch removes gzbz2 from the package dependencies, so strata can be installed on node >= 0.6 (gzbz2 was failing - see #20) and notifies users of node < 0.6 that they need to install gzbz2 manually or upgrade node.
