### PR TITLE
Broken symlink error

### DIFF
--- a/bin/strata
+++ b/bin/strata
@@ -2,7 +2,7 @@
 
 var fs = require("fs"),
     path = require("path"),
-    strata = require("strata"),
+    strata = require("../lib/index"),
     utils = strata.utils;
 
 var app,

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -110,6 +110,10 @@ function generateListing(env, callback, root, pathInfo, scriptName) {
         }
 
         files.forEach(function (file, index) {
+            if (!path.existsSync(path.join(dir, file))) {
+                return;
+            }
+
             var name = path.join(dir, file),
                 ext = path.extname(file),
                 url = path.join(scriptName, pathInfo, file),

--- a/lib/directory.js
+++ b/lib/directory.js
@@ -115,7 +115,6 @@ function generateListing(env, callback, root, pathInfo, scriptName) {
             }
 
             var name = path.join(dir, file),
-                ext = path.extname(file),
                 url = path.join(scriptName, pathInfo, file),
                 stats = fs.statSync(name),
                 mtime = stats.mtime,


### PR DESCRIPTION
When using `strata -d .`, the server will unexpectedly quit if it encounters a symlink to a file or directory that has been deleted

```
[~/workspace]$ mkdir some_dir
[~/workspace]$ mkdir another_dir
[~/workspace]$ cd some_dir/
[~/workspace/some_dir]$ ln -s ../another_dir another_dir
[~/workspace/some_dir]$ rm -rf ../another_dir
[~/workspace/some_dir]$ ls -l
total 8
lrwxrwx---  1  staff  14 Mar  6 16:22 another_dir -> ../another_dir
[~/workspace/some_dir]$ strata -d . &
[1] 38785
[~/workspace/some_dir]$ >> Strata web server version 0.12.2 running on node 0.6.12
>> Listening on 0.0.0.0:1982, CTRL+C to stop

[~/workspace/some_dir]$ curl localhost:1982

fs.js:414
  return binding.stat(pathModule._makeLong(path));
                 ^
Error: ENOENT, no such file or directory 'another_dir'
    at Object.statSync (fs.js:414:18)
    at /usr/local/lib/node_modules/strata/lib/directory.js:116:28
    at Array.forEach (native)
    at Object.oncomplete (/usr/local/lib/node_modules/strata/lib/directory.js:112:15)
curl: (52) Empty reply from server
[1]+  Exit 1                  strata -d .
```

I also changed bin/strata to use ../lib/index so that it uses whatever version of the library the bin file is associated with, not another installed version. Plus this makes it work with `npm link`. If you aren't jazzed about that change, I'm willing to abandon it.
