### PR TITLE
HEAD request should return Content-Length of a GET

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -317,7 +317,10 @@ function call(app, env, callback) {
 
   function handleResponse(status, headers, body) {
     if (env.requestMethod === 'HEAD' || utils.isEmptyBodyStatus(status)) {
-      headers['Content-Length'] = '0';
+      // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13
+      // HEAD should return the content-length that an equivalent GET request would return
+      // even though the HEAD body will be empty
+      if (!headers['Content-Length']) headers['Content-Length'] = '0'; // if Content-Length is set use it
       body = '';
     } else if (typeof body !== 'string' && !headers['Content-Length']) {
       headers['Transfer-Encoding'] = 'chunked';

--- a/test/mock-test.js
+++ b/test/mock-test.js
@@ -33,8 +33,11 @@ describe('mock', function () {
       }), callback);
     });
 
+    // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13
+    // HEAD should return the content-length that an equivalent GET request would return
+    // even though the HEAD body will be empty
     it('returns a Content-Length of 0', function () {
-      assert.equal(headers['Content-Length'], '0');
+      assert.equal(headers['Content-Length'], '2'); // return length of a GET ('OK')
     });
 
     it('returns an empty body', function () {


### PR DESCRIPTION
A HEAD request should return the Content-Length that would have
been returned from a corresponding GET request, even though the
body will be empty.

http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13

For example:

  If a GET /foo should return "Hello" with Content-Length: 5

  Then a HEAD /foo should return '' with Content-Length: 5

Implementers can provide the Content-Length and it should be passed
back through the HEAD response not zeroed out.
