### PR TITLE
build should only use app as cb if cb is undefined

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -38,7 +38,7 @@ var router = require('./router');
  *   });
  */
 module.exports = function (app, callback) {
-  if (typeof app === 'function') {
+  if (typeof callback === 'undefined' && typeof app === 'function') {
     callback = app;
     app = null;
   }

--- a/test/build-test.js
+++ b/test/build-test.js
@@ -1,7 +1,7 @@
 require('./helper');
 var build = strata.build;
 
-describe('build', function () {
+describe('build()', function () {
   var app = build();
 
   app.use(echoRoot);
@@ -41,6 +41,10 @@ describe('build', function () {
     it('maps to the root of the server', function () {
       assert.equal(headers['X-Position'], 'root');
     });
+
+    it('returns status 404 not found', function () {
+      assert.equal(status, 404);
+    });
   });
 
   describe('when /one is requested', function () {
@@ -71,6 +75,268 @@ describe('build', function () {
     });
   });
 });
+
+describe('build(app, callback)', function () {
+
+  function defaultApp(env, callback) {
+    callback(200, { 'Content-Type': 'text/plain' }, 'defaultApp output');
+  }
+
+  var app;
+
+  beforeEach(function (callback) {
+    build(defaultApp, function (buildApp) {
+      app = buildApp;
+
+      app.use(echoRoot);
+      app.use(incCount);
+
+      app.map('/one', function (app) {
+        app.run(function (env, callback) {
+          callback(200, {
+            'Content-Type': 'text/plain',
+            'X-Position': 'one'
+          }, '');
+        });
+      });
+
+      app.use(incCount);
+
+      app.map('/two', function (app) {
+        app.run(function (env, callback) {
+          callback(200, {
+            'Content-Type': 'text/plain',
+            'X-Position': 'two'
+          }, '');
+        });
+      });
+
+      app.use(incCount);
+      callback();
+    });
+  });
+
+  describe('when a non-existent route is requested', function () {
+    beforeEach(function (callback) {
+      call(app, '/doesnt-exist', callback);
+    });
+
+    it('calls all middleware', function () {
+      assert.equal(headers['X-Count'], '3');
+    });
+
+    it('maps to the root of the server', function () {
+      assert.equal(headers['X-Position'], 'root');
+    });
+
+    it('uses the defaultApp provided to build', function () {
+      assert.equal(body, 'defaultApp output');
+    });
+
+    it('returns status 200 ok', function () {
+      assert.equal(status, 200);
+    });
+  });
+
+  describe('when /one is requested', function () {
+    beforeEach(function (callback) {
+      call(app, '/one', callback);
+    });
+
+    it('calls all middleware in front of the call to map', function () {
+      assert.equal(headers['X-Count'], '1');
+    });
+
+    it('properly maps', function () {
+      assert.equal(headers['X-Position'], 'one');
+    });
+  });
+
+  describe('when /two is requested', function () {
+    beforeEach(function (callback) {
+      call(app, '/two', callback);
+    });
+
+    it('calls all middleware in front of the call to map', function () {
+      assert.equal(headers['X-Count'], '2');
+    });
+
+    it('properly maps', function () {
+      assert.equal(headers['X-Position'], 'two');
+    });
+  });
+
+});
+
+describe('build(app, null)', function () {
+
+  function defaultApp(env, callback) {
+    callback(200, { 'Content-Type': 'text/plain' }, 'defaultApp output');
+  }
+
+  var app = build(defaultApp, null);
+
+  app.use(echoRoot);
+  app.use(incCount);
+
+  app.map('/one', function (app) {
+    app.run(function (env, callback) {
+      callback(200, {
+        'Content-Type': 'text/plain',
+        'X-Position': 'one'
+      }, '');
+    });
+  });
+
+  app.use(incCount);
+
+  app.map('/two', function (app) {
+    app.run(function (env, callback) {
+      callback(200, {
+        'Content-Type': 'text/plain',
+        'X-Position': 'two'
+      }, '');
+    });
+  });
+
+  app.use(incCount);
+
+  describe('when a non-existent route is requested', function () {
+    beforeEach(function (callback) {
+      call(app, '/doesnt-exist', callback);
+    });
+
+    it('calls all middleware', function () {
+      assert.equal(headers['X-Count'], '3');
+    });
+
+    it('maps to the root of the server', function () {
+      assert.equal(headers['X-Position'], 'root');
+    });
+
+    it('uses the defaultApp provided to build', function () {
+      assert.equal(body, 'defaultApp output');
+    });
+
+    it('returns status 200 ok', function () {
+      assert.equal(status, 200);
+    });
+  });
+
+  describe('when /one is requested', function () {
+    beforeEach(function (callback) {
+      call(app, '/one', callback);
+    });
+
+    it('calls all middleware in front of the call to map', function () {
+      assert.equal(headers['X-Count'], '1');
+    });
+
+    it('properly maps', function () {
+      assert.equal(headers['X-Position'], 'one');
+    });
+  });
+
+  describe('when /two is requested', function () {
+    beforeEach(function (callback) {
+      call(app, '/two', callback);
+    });
+
+    it('calls all middleware in front of the call to map', function () {
+      assert.equal(headers['X-Count'], '2');
+    });
+
+    it('properly maps', function () {
+      assert.equal(headers['X-Position'], 'two');
+    });
+  });
+
+});
+
+describe('build(callback)', function () {
+
+  var app;
+
+  beforeEach(function (callback) {
+    build(function (buildApp) {
+      app = buildApp;
+
+      app.use(echoRoot);
+      app.use(incCount);
+
+      app.map('/one', function (app) {
+        app.run(function (env, callback) {
+          callback(200, {
+            'Content-Type': 'text/plain',
+            'X-Position': 'one'
+          }, '');
+        });
+      });
+
+      app.use(incCount);
+
+      app.map('/two', function (app) {
+        app.run(function (env, callback) {
+          callback(200, {
+            'Content-Type': 'text/plain',
+            'X-Position': 'two'
+          }, '');
+        });
+      });
+
+      app.use(incCount);
+      callback();
+    });
+  });
+
+  describe('when a non-existent route is requested', function () {
+    beforeEach(function (callback) {
+      call(app, '/doesnt-exist', callback);
+    });
+
+    it('calls all middleware', function () {
+      assert.equal(headers['X-Count'], '3');
+    });
+
+    it('maps to the root of the server', function () {
+      assert.equal(headers['X-Position'], 'root');
+    });
+
+    it('returns status 404 not found', function () {
+      assert.equal(status, 404);
+    });
+  });
+
+  describe('when /one is requested', function () {
+    beforeEach(function (callback) {
+      call(app, '/one', callback);
+    });
+
+    it('calls all middleware in front of the call to map', function () {
+      assert.equal(headers['X-Count'], '1');
+    });
+
+    it('properly maps', function () {
+      assert.equal(headers['X-Position'], 'one');
+    });
+  });
+
+  describe('when /two is requested', function () {
+    beforeEach(function (callback) {
+      call(app, '/two', callback);
+    });
+
+    it('calls all middleware in front of the call to map', function () {
+      assert.equal(headers['X-Count'], '2');
+    });
+
+    it('properly maps', function () {
+      assert.equal(headers['X-Position'], 'two');
+    });
+  });
+
+});
+
 
 // Increments the X-Count header when called.
 function incCount(app) {


### PR DESCRIPTION
build(app, cb) was defined to allow app to be optional, but it should
only shift the arguments if cb is undefined not simply if app is a function
(which if it is passed in, it is always a fn).

Current code would not allow an default app to be passed in, since it
erroneously always shifted it down as a callback.

Changed:

``` javascript
// build.js
module.exports = function (app, callback) {
  // broken, since if app is passed it is also a fn
  if (typeof app === 'function') {  
    callback = app;
    app = null;
  }
```

 to

``` javascript
// build.js
module.exports = function (app, callback) {
  // properly check both before shifting
  if (typeof callback === 'undefined' && typeof app === 'function') {  
    callback = app;
    app = null;
  }
```

By adding the cb is undefined check we can support the following build signatures:
- build()
- build(app, cb)
- build(cb)
- build(app, null)

Added tests to describe and verify these extra 3 scenarios.
