### PR TITLE
HEAD req for stream w/o len should be chunked

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -316,10 +316,14 @@ function call(app, env, callback) {
   }
 
   function handleResponse(status, headers, body) {
-    if (env.requestMethod === 'HEAD' || utils.isEmptyBodyStatus(status)) {
+    if (utils.isEmptyBodyStatus(status)) { // needs to come before Content-Length check
       body = '';
-    } else if (typeof body !== 'string' && !headers['Content-Length']) {
+    }
+    if (typeof body !== 'string' && !headers['Content-Length']) {
       headers['Transfer-Encoding'] = 'chunked';
+    }
+    if (env.requestMethod === 'HEAD') { // set body for HEAD after Transfer-Encoding check
+      body = '';
     }
 
     if (typeof body.resume === 'function') {

--- a/test/mock-test.js
+++ b/test/mock-test.js
@@ -1,5 +1,6 @@
 require('./helper');
 var qs = require('querystring');
+var BufferedStream = require('bufferedstream');
 
 describe('mock', function () {
   describe('a request to utils.ok', function () {
@@ -40,6 +41,54 @@ describe('mock', function () {
     it('returns an empty body', function () {
       assert.equal(body, '');
     });
+  });
+
+  describe('a HEAD request to stream OK response with length', function () {
+    var app = function (env, callback) {
+      assert.equal(env.requestMethod, 'HEAD');
+      var stream = new BufferedStream();
+      stream.end('OK'); // we can do this since it is buffered until next tick
+      callback(200, { "Content-Length": 2 }, stream);
+    };
+
+    beforeEach(function (callback) {
+      call(app, mock.env({
+        requestMethod: 'HEAD'
+      }), callback);
+    });
+
+    it('returns a Content-Length of 2', function () {
+      assert.equal(headers['Content-Length'], '2');
+    });
+
+    it('returns an empty body', function () {
+      assert.equal(body, '');
+    });
+
+  });
+
+  describe('a HEAD request to stream OK response w/o length', function () {
+    var app = function (env, callback) {
+      assert.equal(env.requestMethod, 'HEAD');
+      var stream = new BufferedStream();
+      stream.end('OK'); // we can do this since it is buffered until next tick
+      callback(200, {}, stream);
+    };
+
+    beforeEach(function (callback) {
+      call(app, mock.env({
+        requestMethod: 'HEAD'
+      }), callback);
+    });
+
+    it('returns a Transfer-Encoding of chunked', function () {
+      assert.equal(headers['Transfer-Encoding'], 'chunked');
+    });
+
+    it('returns an empty body', function () {
+      assert.equal(body, '');
+    });
+
   });
 
   describe('env', function () {


### PR DESCRIPTION
A HEAD request for a stream that does not have a content
length should return Transfer-Encoding chunked just
like the equivalent GET.

Currently, a GET where the content length is not available
returns a Transfer-Encoding of chunked, so HEAD
should just do the same.

http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13
