### PR TITLE
mock.call should support binary stream

### DIFF
--- a/lib/mock.js
+++ b/lib/mock.js
@@ -62,14 +62,16 @@ function call(app, env, callback) {
 
   strata.call(app, env, function (status, headers, body) {
     if (body instanceof Stream) {
-      var buffer = '';
+      var bufferArr = [];
 
       body.on('data', function (chunk) {
-        buffer += chunk.toString();
+        bufferArr.push((Buffer.isBuffer(chunk)) ? chunk : new Buffer(chunk)); // combine as Buffer
       });
 
       body.on('end', function () {
-        callback(null, status, headers, buffer);
+        var combinedBuffer = Buffer.concat(bufferArr);
+        var returnVal = (env.mockReturnsBuffer) ? combinedBuffer : combinedBuffer.toString();
+        callback(null, status, headers, returnVal);
       });
     } else {
       callback(null, status, headers, body);


### PR DESCRIPTION
mock.call should support a binary stream and return
a Buffer, but since originally this was returning body
as a string, this can be made as optional.

Use env.mockReturnsBuffer = true to keep
body being returned as a Buffer rather than converting
to a string as previously worked. Without the flag
body will still be converted to string.

Also note: Buffer.concat needs to be used to join chunks
using Buffers rather than simply using toString() otherwise
if utf8 strings are split across chunks it will result in 
invalid data if joining toString() buffer chunks.
