### PR TITLE
Fix session delimiter problem

### DIFF
--- a/lib/session-cookie.js
+++ b/lib/session-cookie.js
@@ -63,9 +63,9 @@ function sessionCookieReader(options) {
       if (cookie) {
         cookie = new Buffer(cookie, 'base64').toString('utf8');
 
-        var parts = cookie.split('--'),
-          data = parts[0],
-          digest = parts[1];
+        var splitPoint = cookie.lastIndexOf('--'),
+          data = cookie.substring(0, splitPoint),
+          digest = cookie.substring(splitPoint + 2);
 
         if (digest === sessionDigest(data, options.secret)) {
           try {


### PR DESCRIPTION
If the session data happens to have '--' in it then the hash check will fail due to the wrong piece of the cookie being used as the hash.  Use `lastIndexOf` instead of `split`.
