### PR TITLE
allow multipart upload of empty file

### DIFF
--- a/lib/multipart/file.js
+++ b/lib/multipart/file.js
@@ -17,6 +17,7 @@ function File(path, type, name) {
   this.type = type;
   this.name = name;
   this.size = 0;
+  this._writeStream = fs.createWriteStream(this.path);
 }
 
 util.inherits(File, EventEmitter);

--- a/test/_files/empty
+++ b/test/_files/empty
@@ -1,0 +1,7 @@
+--AaB03x
+Content-Type: text/plain
+Content-Disposition: attachment; name="files"; filename=empty.txt; modification-date="Wed, 12 Feb 1997 16:29:51 -0500";
+Content-Description: an empty text file
+
+
+--AaB03x--

--- a/test/multipart-test.js
+++ b/test/multipart-test.js
@@ -124,6 +124,34 @@ describe('multipart', function () {
       });
     });
 
+    describe('for an empty text file upload', function () {
+      parseFixture('empty');
+
+      it('correctly parses the file name', function () {
+        var file = params.files;
+        assert.ok(file);
+        assert.equal(file.name, 'empty.txt');
+      });
+
+      it('correctly parses the file content type', function () {
+        var file = params.files;
+        assert.ok(file);
+        assert.equal(file.type, 'text/plain');
+      });
+
+      it('correctly determines the file size', function () {
+        var file = params.files;
+        assert.ok(file);
+        assert.strictEqual(file.size, 0);
+      });
+
+      it("correctly parses the file's contents", function () {
+        var file = params.files;
+        assert.ok(file);
+        assert.equal(fs.readFileSync(file.path, 'utf8'), '');
+      });
+    });
+
     describe('for a text file upload using IE-style filename', function () {
       parseFixture('text_ie');
 


### PR DESCRIPTION
uploading an empty file caused an exception in the multipart/file because writeStream was not previously created.

I added a failing test and then the fix which creates the stream in the constructor.

```
 1) multipart Parser for an empty text file upload "before each" hook:
     TypeError: Cannot call method 'end' of undefined
      at File.end (/Users/barczewskij/projects/strata/lib/multipart/file.js:48:21)
      at Part.Parser.onPart.content (/Users/barczewskij/projects/strata/lib/multipart/parser.js:380:12)
      at Part.EventEmitter.emit (events.js:93:17)
      at Part.end (/Users/barczewskij/projects/strata/lib/multipart/part.js:69:8)
```
