### PR TITLE
upgrade bufferedstream@1.6.0 for node 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
-  - 0.8
+  - "0.8"
+  - "0.10"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git://github.com/mjijackson/strata.git"
   },
   "dependencies": {
-    "bufferedstream": "1.5.1",
+    "bufferedstream": "1.6.0",
     "mime": "1.2.3",
     "strftime": "0.4.6",
     "markdown": "~0.3.1"


### PR DESCRIPTION
bufferedStream@1.6.0 uses setImmediate rather than process.nextTick due to a change in how nextTick works in node 0.10 this prevents a race condition where the loop is called before IO is ready.

Also add node 0.10 to travis config
